### PR TITLE
matches by team

### DIFF
--- a/main.py
+++ b/main.py
@@ -332,22 +332,22 @@ def _get_matches_by_team(table):
     matches = []
     for i, event in enumerate(events):
 
-        event_name = event.find("a", {"class":  "a-reset"}).text
+        event_name = event.find("a", {"class": "a-reset"}).text
         rows = event_matches[i]("tr", {"class": "team-row"})
 
         for row in rows[0:len(rows)]:
             match = {}
             match['date'] = row.find(
-                "td", {"class":  "date-cell"}).find("span").text
+                "td", {"class": "date-cell"}).find("span").text
             match['teams'] = {}
             match['teams']["team_1"] = row.find(
-                "td", {"class":  "team-center-cell"}).find("a", {"class": "team-name team-1"}).text
+                "td", {"class": "team-center-cell"}).find("a", {"class": "team-name team-1"}).text
             match['teams']["team_1_id"] = row.find(
-                "td", {"class":  "team-center-cell"}).find("a", {"class": "team-name team-1"})['href'].split('/')[2]
+                "td", {"class": "team-center-cell"}).find("a", {"class": "team-name team-1"})['href'].split('/')[2]
             match['teams']["team_2"] = row.find(
-                "td", {"class":  "team-center-cell"}).find("a", {"class": "team-name team-2"}).text
+                "td", {"class": "team-center-cell"}).find("a", {"class": "team-name team-2"}).text
             match['teams']["team_2_id"] = row.find(
-                "td", {"class":  "team-center-cell"}).find("a", {"class": "team-name team-2"})['href'].split('/')[2]
+                "td", {"class": "team-center-cell"}).find("a", {"class": "team-name team-2"})['href'].split('/')[2]
             match["confront_name"] = match['teams']["team_1"] + \
                 " X " + match['teams']["team_2"]
             match["championship"] = event_name

--- a/main.py
+++ b/main.py
@@ -337,17 +337,23 @@ def _get_matches_by_team(table):
 
         for row in rows[0:len(rows)]:
             match = {}
-            match['date'] = row.find(
-                "td", {"class": "date-cell"}).find("span").text
+            dateArr = (row.find(
+                "td", {"class": "date-cell"}).find("span").text).split('/')
+
+            dateTextFromArrPadded = _padIfNeeded(dateArr[2]) + "-" + _padIfNeeded(dateArr[1]) + "-" + _padIfNeeded(dateArr[0])
+
+            dateFromHLTV = datetime.datetime.strptime(dateTextFromArrPadded,'%Y-%m-%d').replace(tzinfo=HLTV_ZONEINFO)
+            dateFromHLTV = dateFromHLTV.astimezone(LOCAL_ZONEINFO)
+
+            date = dateFromHLTV.strftime('%Y-%m-%d')
+            match['date'] = date
             match['teams'] = {}
             match['teams']["team_1"] = row.find(
                 "td", {"class": "team-center-cell"}).find("a", {"class": "team-name team-1"}).text
-            match['teams']["team_1_id"] = row.find(
-                "td", {"class": "team-center-cell"}).find("a", {"class": "team-name team-1"})['href'].split('/')[2]
+            match['teams']["team_1_id"] = _findTeamId(row.find( "td", {"class": "team-center-cell"}).find("a", {"class": "team-name team-1"}).text)
             match['teams']["team_2"] = row.find(
                 "td", {"class": "team-center-cell"}).find("a", {"class": "team-name team-2"}).text
-            match['teams']["team_2_id"] = row.find(
-                "td", {"class": "team-center-cell"}).find("a", {"class": "team-name team-2"})['href'].split('/')[2]
+            match['teams']["team_2_id"] = _findTeamId(row.find( "td", {"class": "team-center-cell"}).find("a", {"class": "team-name team-2"}).text)
             match["confront_name"] = match['teams']["team_1"] + \
                 " X " + match['teams']["team_2"]
             match["championship"] = event_name
@@ -355,7 +361,6 @@ def _get_matches_by_team(table):
                 "td", {"class": "matchpage-button-cell"}).find("a")['href']
             match['time'] = get_parsed_page("https://www.hltv.org" + match_url).find(
                 'div', {"class": "timeAndEvent"}).find('div', {"class": "time"}).text
-            match['full_time'] = match['date'] + ' at ' + match['time']
             matches.append(match)
 
     return matches


### PR DESCRIPTION

The matches will displayed on `get_team_info` method, with a new property called `matches`, which give us, the id and name of both teams, the confront name, and the name of the event
```js
{ ...,
'matches': [{'championship': 'ESL Pro League Season 16',
              'confront_name': 'FURIA X Eternal Fire',
              'date': '21/09/2022',
              'full_time': '21/09/2022 at 16:00',
              'teams': {'team_1': 'FURIA',
                        'team_1_id': '8297',
                        'team_2': 'Eternal Fire',
                        'team_2_id': '11251'},
              'time': '16:00'},
             {'championship': 'ESL Pro League Season 16',
              'confront_name': 'FURIA X Movistar Riders',
              'date': '22/09/2022',
              'full_time': '22/09/2022 at 16:00',
              'teams': {'team_1': 'FURIA',
                        'team_1_id': '8297',
                        'team_2': 'Movistar Riders',
                        'team_2_id': '7718'},
              'time': '16:00'}],
 ...,
 }
```