### PR TITLE
Remove an extra item from months dict

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,7 +43,6 @@ def _monthNameToNumber(monthName: str):
         'June': 6,
         'July': 7,
         'August': 8,
-        'Augu': 8,
         'September': 9,
         'October': 10,
         'November': 11,


### PR DESCRIPTION
Removes an extra item from months dictionary in main.py

```diff
def _monthNameToNumber(monthName: str):
    months = {
        'January': 1,
        'February': 2,
        'March': 3,
        'April': 4,
        'May': 5,
        'June': 6,
        'July': 7,
        'August': 8,
-       'Augu': 8,
        'September': 9,
        'October': 10,
        'November': 11,
        'December': 12
    }
    return months[monthName]
```